### PR TITLE
Add DEMO overlay after instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,26 @@
         /* box-shadow: none; */
         /* border: none; */
       }
+
+      /* Demo Overlay */
+      .demo-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: 700;
+        font-size: min(20vw, 20vh);
+        color: rgba(255, 255, 255, 0.3);
+        text-transform: uppercase;
+        pointer-events: none;
+        z-index: 15;
+        opacity: 0;
+        transition: opacity 0.5s;
+      }
     </style>
   </head>
   <body>
@@ -357,6 +377,7 @@
             />
           </div>
         </div>
+        <div class="demo-overlay" id="demoOverlay">DEMO</div>
       </div>
     </div>
     <script>
@@ -481,6 +502,7 @@
         const instructionsOverlay = document.getElementById(
           "instructionsOverlay",
         );
+        const demoOverlay = document.getElementById("demoOverlay");
         const params = getParams();
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
@@ -518,6 +540,7 @@
           setTimeout(() => {
             if (instructionsOverlay.parentNode)
               instructionsOverlay.parentNode.removeChild(instructionsOverlay);
+            if (demoOverlay) demoOverlay.style.opacity = "1";
           }, 400);
         }
         instructionsOverlay.addEventListener("click", hideInstructionsOverlay);


### PR DESCRIPTION
## Summary
- overlay instructions appear at start, then fade
- show a semi-transparent DEMO overlay after instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68683d590c94832fa254f354d1a28af6